### PR TITLE
Fix order of expected and received in (alco)test

### DIFF
--- a/template/bin/template/test/utils_test.ml
+++ b/template/bin/template/test/utils_test.ml
@@ -22,7 +22,7 @@ open {{ project_snake | capitalize }}
 let test_hello_with_name name () =
   let greeting = Utils.greet name in
   let expected = "Hello " ^ name ^ "!" in
-  check string "same string" greeting expected
+  check string "same string" expected greeting
 
 let suite =
   [ "can greet Tom", `Quick, test_hello_with_name "Tom"


### PR DESCRIPTION
The argument order for `check` is
`check type expected received`

E.g. (deliberately breaking `util.ml`)

![image](https://user-images.githubusercontent.com/105627/91760251-e9ffd480-ebca-11ea-89d5-c1f5a8a03722.png)
